### PR TITLE
feat: PostgreSQL 스키마로 전환 및 인터뷰 관련 모델 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,24 +12,145 @@ datasource db {
 
 // User 모델
 model User {
-  id        String   @id @default(cuid())
+  id        BigInt   @id @default(autoincrement())
   email     String?  @unique
-  username  String?  @unique
-  name      String?
-  avatar    String?
-  provider  AuthProvider @default(EMAIL)
-  providerId String? // OAuth provider의 사용자 ID
-  refreshToken String? // Refresh token 저장
+  nickname  String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@index([email])
-  @@index([provider, providerId])
+  oauthAccounts     OAuthAccount[]            @relation("UserOAuthAccounts")
+  refreshTokens     RefreshToken[]            @relation("UserRefreshTokens")
+  interviewSessions InterviewSession[]        @relation("UserInterviewSessions")
+  sessionSummaries  InterviewSessionSummary[] @relation("UserSessionSummaries")
 }
 
-enum AuthProvider {
-  EMAIL
-  GITHUB
-  KAKAO
+// OAuth 계정 모델
+model OAuthAccount {
+  id             BigInt   @id @default(autoincrement())
+  userId         BigInt
+  provider       String
+  providerUserId String
+  providerEmail  String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  user User @relation("UserOAuthAccounts", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerUserId])
+  @@unique([userId, provider])
+  @@index([userId])
 }
 
+// Refresh Token 모델
+model RefreshToken {
+  id            BigInt    @id @default(autoincrement())
+  userId        BigInt
+  tokenHash     String    @unique
+  expiresAt     DateTime
+  revokedAt     DateTime?
+  rotatedFromId BigInt?
+  createdAt     DateTime  @default(now())
+
+  user        User           @relation("UserRefreshTokens", fields: [userId], references: [id], onDelete: Cascade)
+  rotatedFrom RefreshToken?  @relation("TokenRotation", fields: [rotatedFromId], references: [id])
+  rotatedTo   RefreshToken[] @relation("TokenRotation")
+
+  @@index([userId, expiresAt])
+}
+
+// Interview Session 모델
+enum InterviewSessionStatus {
+  in_progress
+  analyzing
+  done
+  failed
+}
+
+model InterviewSession {
+  sessionId      String                 @id
+  userId         BigInt?
+  title          String?
+  topic          String?
+  status         InterviewSessionStatus
+  currentTurn    Int
+  followupStreak Int
+  totalLimitSec  Int
+  turnLimitSec   Int
+  startedAt      DateTime
+  endedAt        DateTime?
+  createdAt      DateTime               @default(now())
+  updatedAt      DateTime               @updatedAt
+
+  user    User?                    @relation("UserInterviewSessions", fields: [userId], references: [id], onDelete: Restrict)
+  turns   InterviewTurn[]          @relation("SessionTurns")
+  report  InterviewReport?         @relation("SessionReport")
+  summary InterviewSessionSummary? @relation("SessionSummary")
+
+  @@index([userId, createdAt])
+  @@index([status, createdAt])
+}
+
+// Interview Turn 모델
+enum QuestionType {
+  base
+  followup
+}
+
+model InterviewTurn {
+  turnId       BigInt       @id @default(autoincrement())
+  sessionId    String
+  turnIndex    Int
+  questionType QuestionType
+  questionText String
+  answerText   String
+  metricsJson  Json?
+  createdAt    DateTime     @default(now())
+  submittedAt  DateTime?
+
+  session InterviewSession @relation("SessionTurns", fields: [sessionId], references: [sessionId], onDelete: Cascade)
+
+  @@unique([sessionId, turnIndex])
+  @@index([sessionId, turnIndex])
+}
+
+// Interview Report 모델
+enum InterviewReportStatus {
+  analyzing
+  done
+  failed
+}
+
+model InterviewReport {
+  reportId      BigInt                @id @default(autoincrement())
+  sessionId     String                @unique
+  status        InterviewReportStatus
+  resultJson    Json?
+  totalScore    Float?
+  durationSec   Int?
+  model         String?
+  promptVersion String?
+  generatedAt   DateTime?
+  createdAt     DateTime              @default(now())
+  updatedAt     DateTime              @updatedAt
+
+  session InterviewSession @relation("SessionReport", fields: [sessionId], references: [sessionId], onDelete: Cascade)
+}
+
+// Interview Session Summary 모델
+model InterviewSessionSummary {
+  summaryId         BigInt   @id @default(autoincrement())
+  sessionId         String   @unique
+  userId            BigInt?
+  title             String
+  topic             String
+  totalScore        Float
+  durationSec       Int
+  competencyAvgJson Json
+  sessionDate       DateTime
+  createdAt         DateTime @default(now())
+
+  session InterviewSession @relation("SessionSummary", fields: [sessionId], references: [sessionId], onDelete: Cascade)
+  user    User?            @relation("UserSessionSummaries", fields: [userId], references: [id], onDelete: Restrict)
+
+  @@index([userId, sessionDate(sort: Desc)])
+}


### PR DESCRIPTION
## 변경 사항

- MySQL에서 PostgreSQL로 데이터베이스 프로바이더 변경
- 인터뷰 세션, 턴, 리포트, 요약 모델 추가
- OAuth 계정 및 리프레시 토큰 모델 분리
- User 모델 구조 개선 (BigInt ID, nickname 필드)
- 모든 관계 및 제약 조건 구현

## 변경 유형

- [x] ✨ 새로운 기능 (기존 기능을 깨뜨리지 않는 새로운 기능 추가)

## 관련 이슈

Closes #2

## 체크리스트

- [x] 코드가 프로젝트의 스타일 가이드를 따릅니다
- [x] 자체 리뷰를 수행했습니다
- [x] 관련 문서를 업데이트했습니다 (스키마 주석)
- [x] 변경 사항이 새로운 경고를 생성하지 않습니다
- [x] Prisma format 검사를 통과합니다

## 테스트 방법

1. `pnpm docker:up`으로 데이터베이스 실행
2. `pnpm prisma:migrate:dev`로 마이그레이션 실행
3. `pnpm prisma:studio`로 스키마 확인

## 추가 정보

- 모든 FK에 relation 설정 완료
- 적절한 삭제 정책 (Cascade/Restrict) 적용
- 인덱스 및 유니크 제약 조건 구현 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced interview session management system with support for multi-turn interviews, detailed performance reports, and session summaries including competency metrics and scoring.

* **Backend Updates**
  * Enhanced authentication infrastructure with OAuth account management, secure refresh token rotation, and improved session tracking capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->